### PR TITLE
FIX attributes schema to allow element and includeElementData

### DIFF
--- a/doip-request-segments/0.DOIP_Op.Retrieve-Request.json
+++ b/doip-request-segments/0.DOIP_Op.Retrieve-Request.json
@@ -19,29 +19,20 @@
       "const": "0.DOIP/Op.Retrieve",
       "description": "operationId: the identifier of the operation to be performed."
     },
-    "attributes": {
+   "attributes": {
       "type": "object",
       "anyOf": [
         {
-          "properties": {
-            "element": {
-              "type": "string",
-              "description": "the identifier (id) of a specific element of the DO serialization"
-            }
-          }
+          "properties": { "element": { "type": "string" } },
+          "required": ["element"],
+          "additionalProperties": false
         },
         {
-          "properties": {
-            "includeElementData": {
-              "type": "boolean",
-              "default": "false",
-              "description": "if true, returns the serialization of the DO including all element data"
-            }
-          }
+          "properties": { "includeElementData": { "type": "boolean", "default": false } },
+          "required": ["includeElementData"],
+          "additionalProperties": false
         }
-      ],
-      "description": "attributes: optional array of JSON properties; operation stipulated.",
-      "additionalProperties": false
+      ]
     },
     "authentication": {
       "type": "object",


### PR DESCRIPTION
This PR adjusts the JSON Schema definition for the attributes property. Previously, additionalProperties: false was applied at the top level of attributes, which prevented element or includeElementData from being recognized as valid properties.

Changes introduced:

Moved additionalProperties: false into each branch of the anyOf clause.

Added explicit required rules for element and includeElementData inside their respective subschemas.

Result:
With this change, the following JSON is now valid against the schema:

{
  "targetId": "example-target",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "example-element-id"
  }
}

This fix ensures that both element and includeElementData are properly validated while still disallowing undefined properties.