### PR TITLE
Update 0.DOIP_Op.Retrieve-Request.json

### DIFF
--- a/doip-request-segments/0.DOIP_Op.Retrieve-Request.json
+++ b/doip-request-segments/0.DOIP_Op.Retrieve-Request.json
@@ -19,20 +19,25 @@
       "const": "0.DOIP/Op.Retrieve",
       "description": "operationId: the identifier of the operation to be performed."
     },
-   "attributes": {
-      "type": "object",
+    "attributes": {
+        "type": "object",
+        "properties": {
+          "element": {
+            "type": "string",
+            "description": "If specified, retrieves the data for that element."
+          },
+        "includeElementData": {
+            "type": "boolean",
+            "description": "If present (true), returns the serialization of the DO including all element data."
+          }
+      },
+      "additionalProperties": false,
+      "minProperties": 1,
       "anyOf": [
-        {
-          "properties": { "element": { "type": "string" } },
-          "required": ["element"],
-          "additionalProperties": false
-        },
-        {
-          "properties": { "includeElementData": { "type": "boolean", "default": false } },
-          "required": ["includeElementData"],
-          "additionalProperties": false
-        }
-      ]
+        { "required": ["element"] },
+        { "required": ["includeElementData"] }
+      ],
+      "description": "Optional request attributes for 0.DOIP/Op.Retrieve; at least one of 'element' or 'includeElementData' must be present."
     },
     "authentication": {
       "type": "object",


### PR DESCRIPTION
Problem: The current schema is not DONA-Specification conform.

tldr: 
The current schema allows only either element or includeElementdata.
The specification does not make that restriction.
Changes should allow both or either one at each time.

Longtext
https://github.com/FDO-Implementations/DOIP-Segments-Specification/blob/fdc2cfd750966274bc2b57af67840952e94cbae0/doip-request-segments/0.DOIP_Op.Retrieve-Request.json#L22C1-L36C7

Allows only either `element` or `includeElementdata`. Thats because of the `"additionalProperties": false` in the respective schemas.
Dona-Doip-Specification V2 does not make this restriction:

> 0.DOIP/Op.Retrieve: An operation to retrieve (some parts of the) information
> represented by the target DO.
> -  Request attributes:
> -  "element": if specified, retrieves the data for that element
> -  "includeElementData": if present, returns the serialization of the DO including all element data
> -  Input: none
> -  Response attributes: none
> -  Output: the default output is the serialization of the object using the default serialization without element data. If "element" was specified, the output is a single bytes segment with the bytes of the specified element. If "includeElementData" was specified, the output is the full serialized DO.

The proposed changes would allow both to be present.

The new schema was tested against and validated all of the following requests:


[
  {
  "targetId": "do:12345",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "metadata"
  }
 },
{
  "targetId": "do:12345",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "includeElementData": true
  }
},
  {
  "targetId": "do:abc",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "payload",
    "includeElementData": true
  }
},
  {
  "targetId": "do:abc",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "payload",
    "includeElementData": true
  }
},
  {
  "targetId": "do:abc",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "payload",
    "includeElementData": true
  }
},
  {
  "targetId": "do:false-flag",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "includeElementData": false
  }
},
  {
  "targetId": "do:empty-element",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": ""
  }
},
  {
  "targetId": "do:üñïčødë",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "teil/数据/сегмент"
  }
},
  {
  "requestId": "req-2025-10-08T10:15:00Z-001",
  "clientId": "client-42",
  "targetId": "do:tokenized",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "checksums"
  },
  "authentication": {
    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  }
},
  {
  "requestId": "req-9",
  "clientId": "cli-key",
  "targetId": "do:keyed",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "includeElementData": true
  },
  "authentication": {
    "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE...."
  }
},
  {
  "requestId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "clientId": "cli-long",
  "targetId": "do:longreq",
  "operationId": "0.DOIP/Op.Retrieve",
  "attributes": {
    "element": "payload/part-1"
  }
}

]

